### PR TITLE
fix: Reduce gap below 'A Better Rebar Solution' title

### DIFF
--- a/style.css
+++ b/style.css
@@ -106,6 +106,7 @@ main section h2 {
 /* About Us Section / A Better Rebar Solution */
 #about h2 { /* Override general section h2 styling */
     text-align: left;
+    margin-bottom: 20px; /* Reduced margin for tighter spacing to content */
 }
 
 .about-content {


### PR DESCRIPTION
- Adjusted the margin-bottom for the H2 title in the #about section to 20px.
- This brings the title closer to the content below it, improving visual balance for that specific layout.